### PR TITLE
remove resource map type from log config

### DIFF
--- a/log.go
+++ b/log.go
@@ -10,7 +10,6 @@ import (
 )
 
 type LogConfig struct {
-	ResourceTypeMap map[string]string
 	Publisher       Publisher
 }
 
@@ -52,7 +51,7 @@ func LoggingMiddleware(config LogConfig) echo.MiddlewareFunc {
 				go func() {
 					profileID := GetProfileIDFromContext(c)
 
-					resourceID := ExtractResourceID(c, config.ResourceTypeMap)
+					resourceID := ExtractResourceID(c)
 
 					logData := LogQueueData{
 						ProfileID:    profileID,
@@ -128,7 +127,7 @@ func GetProfileIDFromContext(c echo.Context) int64 {
 	return profileID
 }
 
-func ExtractResourceID(c echo.Context, resourceTypeMap map[string]string) int64 {
+func ExtractResourceID(c echo.Context) int64 {
 	if idParam := c.Param("id"); idParam != "" {
 		if parsed, err := strconv.ParseInt(idParam, 10, 64); err == nil {
 			return parsed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified resource ID extraction in logging, removing reliance on resource type mapping for improved maintainability. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->